### PR TITLE
4.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,10 @@ services:
 before_install:
   - docker run --name mongodb-container --rm -e TZ=America/Winnipeg -p 27017:27017 -d mongo:3
   - docker run -p 9000:9000 -e "MINIO_ACCESS_KEY=aaa" -e "MINIO_SECRET_KEY=12345678" -d minio/minio server /data
+  - docker run -p 8000:8000 -d amazon/dynamodb-local
   - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - export S3_CONNECTION="s3://aaa:12345678@us-east-1/mybucket?create=true&endpoint=http://127.0.0.1:9000"
+  - export DYNAMODB_CONNECTION="dynamodb://access_key:secret_key@us-east-1/tablename?endpoint=http://127.0.0.1:8000"
 
 install:
   - php -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ services:
 
 before_install:
   - docker run --name mongodb-container --rm -e TZ=America/Winnipeg -p 27017:27017 -d mongo:3
+  - docker run -p 9000:9000 -e "MINIO_ACCESS_KEY=aaa" -e "MINIO_SECRET_KEY=12345678" -d minio/minio server /data
   - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-
+  - export S3_CONNECTION="s3://aaa:12345678@us-east-1/mybucket?create=true&endpoint=http://127.0.0.1:9000"
 
 install:
   - php -i

--- a/AwsDynamoDbKeyValue.md
+++ b/AwsDynamoDbKeyValue.md
@@ -11,6 +11,19 @@ The full connection string can be:
 dynamodb://AKA12345678899:aaaaaaaaaaaaaaaaaaaaaaaaa@us-east-1/mytable
 ```
 
+You can add any extra arguments supported by the DynamoDB api. You can get a full list here:
+ - https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.AwsClient.html#___construct
+
+One of the most populars is the parameter `endpoint` where we can set a custom endpoint to access 
+an DynamoDB compatible interface. 
+
+An example can be: 
+
+```
+s3://AKA12345678899:aaaaaaaaaaaaaaaaaaaaaaaaa@us-east-1/tablename?endpoint=http://localhost:8000
+```
+
+
 # Preparing to use DynamoDb
 
 DynamoDb stores the information slightly different than a model dto structure.

--- a/AwsS3KeyValue.md
+++ b/AwsS3KeyValue.md
@@ -10,6 +10,30 @@ The full connection string can be:
 ```
 s3://AKA12345678899:aaaaaaaaaaaaaaaaaaaaaaaaa@us-east-1/mybucket
 ```
+
+You can add any extra arguments supported by the S3 api. You can get a full list here:
+ - https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.AwsClient.html#___construct
+ - https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.S3.S3Client.html#___construct
+
+One of the most populars is the parameter `endpoint` where we can set a custom endpoint to access 
+an S3 compatible interface. 
+
+An example can be: 
+
+```
+s3://AKA12345678899:aaaaaaaaaaaaaaaaaaaaaaaaa@us-east-1/mybucket?endpoint=http://localhost:9000
+```
+
+There is a specific parameter called `create` from `anydataset/no-sql` that permit create a bucket if 
+it doesn't exist.
+
+Example:
+
+```
+s3://AKA12345678899:aaaaaaaaaaaaaaaaaaaaaaaaa@us-east-1/mybucket?create=true
+```
+ 
+
 # List all objects
 
 ```php

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ vendor/bin/phpunit testsdb/MongoDbDriverTest.php
 
 You need setup your environment with:
  
-- DYNAMODB_CONNECTION = "dynamodb://access_key:secret_key@region/bucketname"
+- DYNAMODB_CONNECTION = "dynamodb://access_key:secret_key@region/tablename"
 
 Once defined:
 

--- a/src/AwsDynamoDbDriver.php
+++ b/src/AwsDynamoDbDriver.php
@@ -34,14 +34,21 @@ class AwsDynamoDbDriver implements KeyValueInterface
     {
         $uri = new Uri($connectionString);
 
-        $this->dynamoDbClient = new DynamoDbClient([
+        $defaultParameters = [
             'version'     => 'latest',
             'region'      => $uri->getHost(),
             'credentials' => [
                 'key'    => $uri->getUsername(),
                 'secret' => $uri->getPassword(),
             ],
-        ]);
+        ];
+
+        $extraParameters = [];
+        parse_str($uri->getQuery(), $extraParameters);
+
+        $dynamoDbParameters = array_merge($defaultParameters, $extraParameters);
+
+        $this->dynamoDbClient = new DynamoDbClient($dynamoDbParameters);
 
         $this->table = preg_replace('~^/~', '', $uri->getPath());
     }

--- a/src/AwsDynamoDbDriver.php
+++ b/src/AwsDynamoDbDriver.php
@@ -214,4 +214,12 @@ class AwsDynamoDbDriver implements KeyValueInterface
     {
         // TODO: Implement removeBatch() method.
     }
+
+    public function getTablename() {
+        return $this->table;
+    }
+
+    public function client() {
+        return $this->dynamoDbClient;
+    }
 }

--- a/src/AwsS3Driver.php
+++ b/src/AwsS3Driver.php
@@ -191,4 +191,8 @@ class AwsS3Driver implements KeyValueInterface
     {
         // TODO: Implement removeBatch() method.
     }
+
+    public function client() {
+        return $this->s3Client;
+    }
 }


### PR DESCRIPTION

- AwsS3Driver - Use local S3 for test
- AwsS3Driver - Added `create` parameter to create a bucket if it doesn't exist.
- AwsS3Driver - Exposing AWS client
- AwsDynamoDbDriver - Exposing AWS client and tablename
- AwsDynamoDbDriver - Enable receive extra arguments 
- AwsDynamoDbDriver - Use local dynamodb for test
- Update documentation